### PR TITLE
fix: vec_sparse_fps.hpp のコンパイルエラーを修正 (Fixes #32)

### DIFF
--- a/library/polynomial/vec_sparse_fps.hpp
+++ b/library/polynomial/vec_sparse_fps.hpp
@@ -63,7 +63,7 @@ namespace suisen {
             std::sort(data.begin(), data.end(), [](auto &p1, auto &p2) { return p1.first < p2.first; });
             VecSparseFPS h;
             for (auto &[i, a] : data) {
-                h.add_to_last(i, std::move(a));
+                h.add_to_last({i, std::move(a)});
             }
             return h;
         }
@@ -116,7 +116,7 @@ namespace suisen {
 
         static value_type bostan_mori(VecSparseFPS P, std::vector<value_type> Q, long long m) {
             for (; m; m >>= 1) {
-                std::vector<mint> mQ = Q;
+                std::vector<value_type> mQ = Q;
                 for (int i = 1; i < int(Q.size()); i += 2) mQ[i] = -mQ[i];
                 auto nP = P * mQ;
                 P.clear();


### PR DESCRIPTION
Resolves #32

## 概要
`library/polynomial/vec_sparse_fps.hpp` のコンパイルエラーを修正しました。

## 変更内容
- `operator*` 内で、`std::vector<value_type>` を `add_to_last` に渡す箇所の呼び出し形式を修正しました。  
  - `add_to_last(i, std::move(a))` の形だと引数が一致せずコンパイルできないため、`std::pair` を渡す形に変更しています。
- `bostan_mori` 内で `std::vector<mint>` となっていた箇所を `std::vector<value_type>` に修正しました。  
  - `mint` が未定義の場合にヘッダ単体でコンパイルできない問題を解消します。

## 影響範囲
- API 変更はありません。
- 意図としてはコンパイルエラーの解消のみで、挙動の変更はありません。

## 補足
- 本 PR の変更も本リポジトリの CC0 ライセンスに従う想定です。