### PR TITLE
fix: set_power_series.hpp を Clang 等でもコンパイルできるよう修正

### DIFF
--- a/library/math/set_power_series.hpp
+++ b/library/math/set_power_series.hpp
@@ -12,7 +12,7 @@ namespace suisen {
 
         using polynomial_type = ranked_subset_transform::polynomial_t<value_type>;
 
-        using base_type::vector;
+        using base_type::base_type;
 
         SetPowerSeries(): SetPowerSeries(0) {}
         SetPowerSeries(size_type n): SetPowerSeries(n, value_type{ 0 }) {}
@@ -125,7 +125,7 @@ namespace suisen {
 
         struct ZetaSPS: public std::vector<polynomial_type> {
             using base_type = std::vector<polynomial_type>;
-            using base_type::vector;
+            using base_type::base_type;
             ZetaSPS() = default;
             ZetaSPS(const SetPowerSeries<value_type>& f): base_type::vector(ranked_subset_transform::ranked_zeta(f)), _d(f.cardinality()) {}
 


### PR DESCRIPTION
## 概要
`library/math/set_power_series.hpp` において、GCC では許容される一方で Clang 等ではコンパイルエラーになる「基底クラス(std::vector)のコンストラクタ継承に関する using 記法」を修正しました。

## 変更内容
- `SetPowerSeries` および内部の `ZetaSPS` で、基底クラスに対する `using` 宣言を Clang 等でも受理される表現に修正しました。

## 影響範囲
- 変更は `using` 宣言のみで、API/挙動には影響しない想定です。（コンパイル互換性の改善）

## 補足
- 本件は Issue は立てていません。修正 PR を直接投げるほうがメンテナ負担が小さいと判断しました。
- 本 PR の変更も本リポジトリの CC0 ライセンスに従う想定です。