### PR TITLE
fix: dual_segment_tree.hpp を Clang および clangd でも扱えるよう修正

### DIFF
--- a/library/datastructure/segment_tree/dual_segment_tree.hpp
+++ b/library/datastructure/segment_tree/dual_segment_tree.hpp
@@ -28,12 +28,6 @@ namespace suisen {
             }
         }
     };
-
-    template <typename T, typename F, T(*mapping)(F, T), F(*composition)(F, F), F(*id)()>
-    DualSegmentTree(int, T)->DualSegmentTree<T, F, mapping, composition, id>;
-
-    template <typename T, typename F, T(*mapping)(F, T), F(*composition)(F, F), F(*id)()>
-    DualSegmentTree(std::vector<T>)->DualSegmentTree<T, F, mapping, composition, id>;
 } // namespace suisen
 
 


### PR DESCRIPTION
## 概要
`library/datastructure/segment_tree/dual_segment_tree.hpp` にある `DualSegmentTree` の CTAD 用 deduction guide が、
Clang/clangd では `Deduction guide template contains template parameters that cannot be deduced`
（clangd: `deduction_guide_template_not_deducible`）としてエラーになります。

推論元の引数（`int, T` / `std::vector<T>`）から `F` および関数ポインタ（`mapping/composition/id`）が推論できないためです。

## 変更内容
* `DualSegmentTree(int, T) -> ...` と `DualSegmentTree(std::vector<T>) -> ...` の 2 本の deduction guide を削除しました。

## 影響範囲
* 既存の `DualSegmentTree<T, F, mapping, composition, id>` の明示指定・型 alias による利用には影響しません。
* 上記 deduction guide は（推論できないテンプレ引数を含むため）Clang 系ではエラーになり、
  実用上も CTAD による構築を成立させられないため、削除による影響は限定的です（解析/コンパイル互換性の改善）。

## 補足
* 本件も Issue は立てていません（PR のほうがメンテナ負担が小さいと判断しました）。
* 本 PR の変更も本リポジトリの CC0 ライセンスに従う想定です。